### PR TITLE
Removed banners from Woocommerce Checkout and Cart pages.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 # Change log
 
+## [[1.2.5]]
+
+### Changed
+- Removed banners from Woocommerce Checkout and Cart pages.
+
 
 ## [[1.2.4]](https://github.com/lightspeeddevelopment/lsx-banners/releases/tag/1.2.4) - 2020-03-30
 

--- a/classes/class-lsx-banners-frontend.php
+++ b/classes/class-lsx-banners-frontend.php
@@ -384,6 +384,11 @@ class LSX_Banners_Frontend extends LSX_Banners {
 			$title_position = 'centered';
 		}
 
+		// Cart and Checkout won't have banners of any kind.
+		if ( function_exists( 'is_woocommerce' ) && ( is_checkout() || is_cart() ) ) {
+			return;
+		}
+
 		if ( ! empty( $show_slider ) || ! empty( $banner_image ) || ! empty( $embed_video ) || ! empty( $bg_color ) ) {
 			add_filter( 'lsx_global_header_disable', '__return_true' );
 			?>


### PR DESCRIPTION
### Description of the Change

This change makes sure that on cart or checkout woocommerce pages there is NO lsx banner.

### Benefits

A simpler and more effective checkout process.

### Possible Drawbacks

Need to check important sites and make sure the cart and checkout page look ok.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx/issues/350

### Changelog Entry

Removed banners from Woocommerce Checkout and Cart pages.
